### PR TITLE
src: service: Use Zenoh sample timestamp for MCAP publish_time

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -266,14 +266,17 @@ impl Service {
                 .get_mut(&topic)
                 .expect("Failed to get mcap channel");
             let now = SystemTime::now();
-            let duration = now.duration_since(UNIX_EPOCH).unwrap();
-            let timestamp = duration.as_nanos() as u64;
+            let log_time = now.duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
+            let publish_time = sample
+                .timestamp()
+                .map(|ts| ts.get_time().as_nanos())
+                .unwrap_or(log_time);
             if let Err(e) = writer.write_to_known_channel(
                 &mcap::records::MessageHeader {
                     channel_id: channel.channel_id,
                     sequence: channel.sequence,
-                    log_time: timestamp,
-                    publish_time: timestamp,
+                    log_time,
+                    publish_time,
                 },
                 &payload.to_bytes(),
             ) {


### PR DESCRIPTION
Previously both log_time and publish_time were set to the recorder's wall-clock time at the moment the sample was received. This meant publish_time included variable network and processing delays, making it unsuitable as a timing reference for downstream consumers.

Now publish_time uses the Zenoh HLC timestamp carried on each sample, which is set closer to the original publication time by the sender, falling back to log_time when no Zenoh timestamp is available.

This improves extracted video smoothness when the extractor falls back to MCAP publish_time (e.g. when the Foxglove payload timestamp is zero), and provides a more accurate publication time reference for any MCAP consumer.