### PR TITLE
Improve local recording p2

### DIFF
--- a/src/mavlink.rs
+++ b/src/mavlink.rs
@@ -22,6 +22,10 @@ impl VehicleArmGate {
         }
     }
 
+    pub fn is_armed(&self) -> bool {
+        self.is_armed
+    }
+
     /// Updates arm state from a Zenoh sample. Returns `Some` only when the armed state changes.
     #[instrument(skip_all)]
     pub fn update(&mut self, topic: &str, payload: &ZBytes) -> Option<ArmState> {

--- a/src/mcap.rs
+++ b/src/mcap.rs
@@ -21,13 +21,6 @@ pub struct Channel {
 }
 
 impl Mcap {
-    pub fn inactive() -> Self {
-        Self {
-            writer: None,
-            channel: HashMap::new(),
-        }
-    }
-
     #[instrument(skip_all, fields(path = %path.display()))]
     pub fn try_new(path: &std::path::Path) -> Result<Self> {
         info!("Creating mcap file");
@@ -56,11 +49,6 @@ impl Mcap {
         };
         writer.flush().context("Failed to flush MCAP writer")?;
         Ok(())
-    }
-
-    #[inline]
-    pub fn is_recording(&self) -> bool {
-        self.writer.is_some()
     }
 
     #[inline]

--- a/src/service.rs
+++ b/src/service.rs
@@ -15,7 +15,6 @@ pub struct Service {
     subscriber: Subscriber<FifoChannelHandler<Sample>>,
     mcap: Mcap,
     vehicle_arm: VehicleArmGate,
-    recorder_path: std::path::PathBuf,
     schema_path: Option<std::path::PathBuf>,
 }
 
@@ -33,6 +32,7 @@ fn generate_filename() -> String {
 }
 
 impl Service {
+    #[instrument()]
     pub async fn new(
         config: Config,
         recorder_path: std::path::PathBuf,
@@ -46,12 +46,15 @@ impl Service {
             .await
             .expect("Failed to declare global zenoh subscriber");
 
+        let path = recorder_path.join(generate_filename());
+        info!("Opening recording session");
+
+        let mcap = Mcap::try_new(&path).unwrap();
         Self {
             session,
             subscriber,
-            mcap: Mcap::inactive(),
+            mcap,
             vehicle_arm: VehicleArmGate::new(),
-            recorder_path,
             schema_path,
         }
     }
@@ -68,27 +71,12 @@ impl Service {
             let _sample_span = span.enter();
 
             match self.vehicle_arm.update(topic, payload) {
-                Some(ArmState::Armed) if !self.mcap.is_recording() => {
-                    info!("Vehicle is armed, starting recording");
-                    let filename = generate_filename();
-                    let path = self.recorder_path.join(filename);
-                    match Mcap::try_new(&path) {
-                        Ok(mcap) => self.mcap = mcap,
-                        Err(error) => {
-                            error!(path = %path.display(), %error, "Failed to start MCAP recording");
-                        }
-                    }
-                }
-                Some(ArmState::Disarmed) if self.mcap.is_recording() => {
-                    info!("Vehicle is disarmed, stopping recording");
-                    if let Err(error) = self.mcap.finish() {
-                        error!(%error, "Failed to stop MCAP recording");
-                    }
-                }
+                Some(ArmState::Armed) => info!("Vehicle is armed"),
+                Some(ArmState::Disarmed) => info!("Vehicle is disarmed"),
                 _ => {}
             }
 
-            if !self.mcap.is_recording() {
+            if !self.should_record_sample(topic) {
                 continue;
             }
 
@@ -129,6 +117,14 @@ impl Service {
                 }
                 last_flush = now;
             }
+        }
+    }
+
+    fn should_record_sample(&self, topic: &str) -> bool {
+        if topic.starts_with("mavlink/") || topic.starts_with("video/") {
+            self.vehicle_arm.is_armed()
+        } else {
+            true
         }
     }
 }


### PR DESCRIPTION
Depends on #20. Helps #19.

In this patch, we change the basic file behavior:
* Before:
  * Creates a new file on vehicle disarm->arm transition;
  * Closes the file on vehicle arm->disarm transition;
  * Discards every Zenoh message while the vehicle is disarmed;
* After: 
  * Creates a new file whenever blueos-recorder is started (per-session file);
  * Writes all Zenoh messages to the file unless they are `mavlink/` or `video/` (blueos and extension logs are now available);

